### PR TITLE
Fixed an issue with 32 bit devices (i.e. iPhone 4S).

### DIFF
--- a/Pod/Classes/StringExtension.swift
+++ b/Pod/Classes/StringExtension.swift
@@ -39,4 +39,11 @@ extension String {
         }
         return self.substringWithRange((self.startIndex.advancedBy(fromInclusively)..<self.startIndex.advancedBy(toExclusively)))
     }
+    
+    /**
+     - returns: True if this string contains only digits.
+     */
+    func isNumeric() -> Bool {
+        return characters.reduce(true, combine: { return $0 && "0123456789".characters.contains($1)})
+    }
 }

--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -97,7 +97,7 @@ public class NumberInputTextField: StylizedTextField {
         let newTextFormatted = textFieldTextFormatted.stringByReplacingCharactersInRange(range, withString: string)
         let newTextUnformatted = cardNumberFormatter.unformattedCardNumber(newTextFormatted)
         
-        if !newTextUnformatted.isEmpty && !newTextUnformatted.characters.reduce(true, combine: { return $0 && "0123456789".characters.contains($1)}) {
+        if !newTextUnformatted.isEmpty && !newTextUnformatted.isNumeric() {
             flashTextFieldInvalid()
             return false
         }

--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -96,8 +96,8 @@ public class NumberInputTextField: StylizedTextField {
         // Text in text field after applying changes, formatted and unformatted:
         let newTextFormatted = textFieldTextFormatted.stringByReplacingCharactersInRange(range, withString: string)
         let newTextUnformatted = cardNumberFormatter.unformattedCardNumber(newTextFormatted)
-
-        if !newTextUnformatted.isEmpty && UInt(newTextUnformatted) == nil {
+        
+        if !newTextUnformatted.isEmpty && !newTextUnformatted.characters.reduce(true, combine: { return $0 && "0123456789".characters.contains($1)}) {
             flashTextFieldInvalid()
             return false
         }


### PR DESCRIPTION
* Using `UInt(string) == nil` to check whether a string contains only numeric characters fails on 32 bit devices: entering a number of > 2^32 results in nil, even though it's still numeric. Instead use string operations for this.