### PR TITLE
Updated card number range for Discover

### DIFF
--- a/Pod/Classes/Cards/Default Card Types/Discover.swift
+++ b/Pod/Classes/Cards/Default Card Types/Discover.swift
@@ -14,7 +14,7 @@ public struct Discover: CardType {
     
     public let CVCLength = 3
     
-    public let identifyingDigits = Set(644...649).union( Set(622126...622925) ).union( Set([6011]) )
+    public let identifyingDigits = Set(644...649).union( Set([6011]) ).union(Set([65]))
 
     public init() {
         


### PR DESCRIPTION
- According to https://en.wikipedia.org/wiki/Bank_card_number, the range between 622126 and 622925 is under Discover but according to http://www.stevemorse.org/ssn/List_of_Bank_Identification_Numbers.html, such range is under China Union Pay. I actually have a Union Pay card that starts at 6225. After discussion with @DannyVancura , our thought is that there should be some cooperation between Discover and Union Pay and Union pay used to be treated as Discover in the US. Since we are supporting Union Pay, it would be better to treat them as Union Pay itself instead of Discover.

- 65 is also part of Discover.