### PR TITLE
Added proper right-to-left language support.

### DIFF
--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -67,7 +67,22 @@ public extension CardTextField {
         numberInputTextField?.alpha = 1
         numberInputTextField.becomeFirstResponder()
         numberInputTextField.layer.mask = nil
+        
+        // Move card info view
         let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
         cardInfoView?.transform = CGAffineTransformMakeTranslation(offset, 0)
+        
+        // If card info view is moved with an animation, wait for it to finish before
+        // showing the full card number to avoid overlapping on RTL language.
+        if cardInfoView?.layer.animationKeys() != nil {
+            dispatch_after(dispatch_time(
+                DISPATCH_TIME_NOW,
+                Int64(viewAnimationDuration * Double(NSEC_PER_SEC))),
+                           dispatch_get_main_queue()) { [weak self] _ in
+                self?.numberInputTextField?.layer.mask = nil
+            }
+        } else {
+            numberInputTextField?.layer.mask = nil
+        }
     }
 }

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -91,10 +91,16 @@ public extension CardTextField {
     public func moveCardNumberIn() {
         let infoTextFields: [UITextField?] = [monthTextField, yearTextField, cvcTextField]
         infoTextFields.forEach({$0?.resignFirstResponder()})
-        numberInputTextField?.transform = CGAffineTransformIdentity
-        numberInputTextField?.alpha = 1
-        numberInputTextField.becomeFirstResponder()
-        numberInputTextField.layer.mask = nil
+        if isRightToLeftLanguage {
+            UIView.performWithoutAnimation {
+                self.numberInputTextField?.alpha = 1
+                self.numberInputTextField?.transform = CGAffineTransformIdentity
+            }
+        } else {
+            numberInputTextField?.alpha = 1
+            numberInputTextField.becomeFirstResponder()
+            numberInputTextField?.transform = CGAffineTransformIdentity
+        }
         
         // Move card info view
         let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
@@ -111,6 +117,12 @@ public extension CardTextField {
             }
         } else {
             numberInputTextField?.layer.mask = nil
+        }
+        
+        if isRightToLeftLanguage {
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(viewAnimationDuration / 2.0 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()){
+                self.numberInputTextField.becomeFirstResponder()
+            }
         }
     }
 }

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -58,8 +58,15 @@ public extension CardTextField {
                 numberInputTextField.layer.mask = shapeLayer
                 numberInputTextField?.transform = CGAffineTransformIdentity
             } else {
-                numberInputTextField?.transform =
-                    CGAffineTransformMakeTranslation(-rect.origin.x, 0)
+                if shouldMoveAnimated {
+                    numberInputTextField?.transform =
+                        CGAffineTransformMakeTranslation(-rect.origin.x, 0)
+                } else {
+                    UIView.performWithoutAnimation { [weak self] _ in
+                        self?.numberInputTextField?.transform =
+                            CGAffineTransformMakeTranslation(-rect.origin.x, 0)
+                    }
+                }
             }
         } else {
             numberInputTextField?.alpha = 0

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -39,8 +39,16 @@ public extension CardTextField {
         }
         numberInputTextField?.becomeFirstResponder()
         if let rect = numberInputTextField?.rectForLastGroup() {
-            numberInputTextField?.transform =
-                CGAffineTransformMakeTranslation(-rect.origin.x, 0)
+            if isRightToLeftLanguage {
+                let shapeLayer = CAShapeLayer()
+                let path = CGPathCreateWithRect(rect, nil)
+                shapeLayer.path = path
+                numberInputTextField.layer.mask = shapeLayer
+                numberInputTextField?.transform = CGAffineTransformIdentity
+            } else {
+                numberInputTextField?.transform =
+                    CGAffineTransformMakeTranslation(-rect.origin.x, 0)
+            }
         } else {
             numberInputTextField?.alpha = 0
         }
@@ -58,6 +66,8 @@ public extension CardTextField {
         numberInputTextField?.transform = CGAffineTransformIdentity
         numberInputTextField?.alpha = 1
         numberInputTextField.becomeFirstResponder()
-        cardInfoView?.transform = CGAffineTransformMakeTranslation(superview!.bounds.width, 0)
+        numberInputTextField.layer.mask = nil
+        let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
+        cardInfoView?.transform = CGAffineTransformMakeTranslation(offset, 0)
     }
 }

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -500,7 +500,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     public override func touchesEnded(touches: Set<UITouch>, withEvent event: UIEvent?) {
         // Detect touches in card number text field as long as the detail view is on top of it
         touches.forEach({ touch -> () in
-            let point = touch.locationInView(self)
+            let point = touch.locationInView(numberInputTextField)
             if (numberInputTextField?.pointInside(point, withEvent: event) ?? false) && [monthTextField,yearTextField,cvcTextField, slashLabel].reduce(true, combine: { (currentValue: Bool, view: UIView?) -> Bool in
                 let pointInView = touch.locationInView(view)
                 return currentValue && !(view?.pointInside(pointInView, withEvent: event) ?? false)

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -309,16 +309,15 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         monthTextField?.deleteBackwardCallback = {_ -> Void in self.numberInputTextField?.becomeFirstResponder()}
         yearTextField?.deleteBackwardCallback = {_ -> Void in self.monthTextField?.becomeFirstResponder()}
         
+        // Set the text alignment of cvc and month text field manually, as there is no
+        // counterpart to `right` (in a left-to-right script) that changes based on localization
+        // and can be set in a Nib.
         if isRightToLeftLanguage {
             cvcTextField.textAlignment = .Left
             monthTextField.textAlignment = .Left
-            yearTextField.textAlignment = .Right
-            numberInputTextField.textAlignment = .Right
         } else {
             cvcTextField.textAlignment = .Right
             monthTextField.textAlignment = .Right
-            yearTextField.textAlignment = .Left
-            numberInputTextField.textAlignment = .Left
         }
         
         let textFields: [UITextField?] = [numberInputTextField, cvcTextField, monthTextField, yearTextField]

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -274,14 +274,14 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         // Reset gesture recognizers
         [firstObjectInNib, cardInfoView].forEach({$0?.gestureRecognizers = []})
         
-        let leftSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberOutAnimated))
-        leftSwipeGestureRecognizer.direction = isRightToLeftLanguage ? .Right : .Left
-        firstObjectInNib.addGestureRecognizer(leftSwipeGestureRecognizer)
+        let hideCardNumberSwipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberOutAnimated))
+        hideCardNumberSwipeRecognizer.direction = isRightToLeftLanguage ? .Right : .Left
+        firstObjectInNib.addGestureRecognizer(hideCardNumberSwipeRecognizer)
         
         [firstObjectInNib, cardInfoView].forEach({
-            let rightSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberInAnimated))
-            rightSwipeGestureRecognizer.direction = isRightToLeftLanguage ? .Left : .Right
-            $0?.addGestureRecognizer(rightSwipeGestureRecognizer)
+            let showCardNumberSwipeRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberInAnimated))
+            showCardNumberSwipeRecognizer.direction = isRightToLeftLanguage ? .Left : .Right
+            $0?.addGestureRecognizer(showCardNumberSwipeRecognizer)
         })
         
         setupTextFieldDelegates()

--- a/Pod/Classes/UI/CardView.xib
+++ b/Pod/Classes/UI/CardView.xib
@@ -22,15 +22,15 @@
             </connections>
         </placeholder>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
-        <view contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" id="iN0-l3-epB">
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
             <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
             <subviews>
-                <view clipsSubviews="YES" contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" translatesAutoresizingMaskIntoConstraints="NO" id="UFG-yT-gmg">
-                    <rect key="frame" x="31" y="2" width="530" height="596"/>
+                <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UFG-yT-gmg">
+                    <rect key="frame" x="31" y="2" width="538" height="596"/>
                     <subviews>
-                        <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000000000000000" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="T6o-6e-fLS" customClass="NumberInputTextField" customModule="Caishen" customModuleProvider="target">
-                            <rect key="frame" x="4" y="0.0" width="526" height="596"/>
+                        <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000000000000000" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="T6o-6e-fLS" customClass="NumberInputTextField" customModule="Caishen" customModuleProvider="target">
+                            <rect key="frame" x="4" y="0.0" width="538" height="596"/>
                             <accessibility key="accessibilityConfiguration" label="Card Number"/>
                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
                             <textInputTraits key="textInputTraits"/>
@@ -38,10 +38,10 @@
                                 <userDefinedRuntimeAttribute type="string" keyPath="cardNumberSeparator" value=" - "/>
                             </userDefinedRuntimeAttributes>
                         </textField>
-                        <view contentMode="scaleToFill" semanticContentAttribute="forceLeftToRight" translatesAutoresizingMaskIntoConstraints="NO" id="8iN-aK-Jz9">
-                            <rect key="frame" x="0.0" y="0.0" width="530" height="596"/>
+                        <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="8iN-aK-Jz9">
+                            <rect key="frame" x="0.0" y="0.0" width="538" height="596"/>
                             <subviews>
-                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="MM" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5cX-Z5-afy" customClass="MonthInputTextField" customModule="Caishen" customModuleProvider="target">
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="right" contentVerticalAlignment="center" placeholder="MM" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="5cX-Z5-afy" customClass="MonthInputTextField" customModule="Caishen" customModuleProvider="target">
                                     <rect key="frame" x="229" y="0.0" width="37" height="596"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" label="Expiration Month"/>
@@ -51,17 +51,7 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="20"/>
                                     <textInputTraits key="textInputTraits"/>
                                 </textField>
-                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="YY" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CgE-Em-qHJ" customClass="YearInputTextField" customModule="Caishen" customModuleProvider="target">
-                                    <rect key="frame" x="272" y="0.0" width="37" height="596"/>
-                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                    <accessibility key="accessibilityConfiguration" label="Expiration Year"/>
-                                    <constraints>
-                                        <constraint firstAttribute="width" constant="37" id="YKf-J2-WJy"/>
-                                    </constraints>
-                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
-                                    <textInputTraits key="textInputTraits"/>
-                                </textField>
-                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" semanticContentAttribute="forceLeftToRight" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DD8-kX-0ru">
+                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="/" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DD8-kX-0ru">
                                     <rect key="frame" x="266" y="288" width="6" height="21"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration">
@@ -70,8 +60,8 @@
                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                     <nil key="highlightedColor"/>
                                 </label>
-                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="CVC" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HOM-PC-B5m" customClass="CVCInputTextField" customModule="Caishen" customModuleProvider="target">
-                                    <rect key="frame" x="309" y="0.0" width="221" height="596"/>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="CVC" textAlignment="right" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="HOM-PC-B5m" customClass="CVCInputTextField" customModule="Caishen" customModuleProvider="target">
+                                    <rect key="frame" x="309" y="0.0" width="229" height="596"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" label="Card Verification Code"/>
                                     <constraints>
@@ -84,6 +74,16 @@
                                             <exclude reference="Qg6-cj-7bj"/>
                                         </mask>
                                     </variation>
+                                </textField>
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="YY" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CgE-Em-qHJ" customClass="YearInputTextField" customModule="Caishen" customModuleProvider="target">
+                                    <rect key="frame" x="272" y="0.0" width="37" height="596"/>
+                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                    <accessibility key="accessibilityConfiguration" label="Expiration Year"/>
+                                    <constraints>
+                                        <constraint firstAttribute="width" constant="37" id="YKf-J2-WJy"/>
+                                    </constraints>
+                                    <fontDescription key="fontDescription" type="system" pointSize="20"/>
+                                    <textInputTraits key="textInputTraits"/>
                                 </textField>
                             </subviews>
                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -106,7 +106,7 @@
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="8iN-aK-Jz9" secondAttribute="bottom" id="2qC-nH-TOb"/>
-                        <constraint firstItem="T6o-6e-fLS" firstAttribute="trailing" secondItem="8iN-aK-Jz9" secondAttribute="trailing" id="2wV-fp-QSh"/>
+                        <constraint firstItem="T6o-6e-fLS" firstAttribute="trailing" secondItem="8iN-aK-Jz9" secondAttribute="trailing" constant="4" id="2wV-fp-QSh"/>
                         <constraint firstItem="T6o-6e-fLS" firstAttribute="top" secondItem="UFG-yT-gmg" secondAttribute="top" id="33E-7t-cqB"/>
                         <constraint firstAttribute="trailing" secondItem="8iN-aK-Jz9" secondAttribute="trailing" id="3nI-Om-zhN"/>
                         <constraint firstAttribute="bottom" secondItem="T6o-6e-fLS" secondAttribute="bottom" id="5A1-86-yL3"/>
@@ -126,7 +126,7 @@
                         </mask>
                     </variation>
                 </view>
-                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" semanticContentAttribute="forceLeftToRight" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Unknown" translatesAutoresizingMaskIntoConstraints="NO" id="puU-AL-gPV">
+                <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Unknown" translatesAutoresizingMaskIntoConstraints="NO" id="puU-AL-gPV">
                     <rect key="frame" x="1" y="2" width="30" height="596"/>
                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     <constraints>
@@ -138,13 +138,13 @@
                         </userDefinedRuntimeAttribute>
                     </userDefinedRuntimeAttributes>
                 </imageView>
-                <button opaque="NO" contentMode="scaleAspectFit" semanticContentAttribute="forceLeftToRight" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WR5-rr-22S">
-                    <rect key="frame" x="565" y="285" width="30" height="30"/>
+                <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WR5-rr-22S">
+                    <rect key="frame" x="569" y="285" width="30" height="30"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="JV6-ku-yYG"/>
                         <constraint firstAttribute="height" constant="30" id="xUL-fT-uar"/>
                     </constraints>
-                    <state key="normal" title="⇤"/>
+                    <state key="normal" title="&gt;"/>
                 </button>
             </subviews>
             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -152,10 +152,10 @@
                 <constraint firstItem="UFG-yT-gmg" firstAttribute="centerY" secondItem="puU-AL-gPV" secondAttribute="centerY" id="16X-0R-PgK"/>
                 <constraint firstItem="UFG-yT-gmg" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="2" id="1Gi-Je-Nb6"/>
                 <constraint firstItem="T6o-6e-fLS" firstAttribute="leading" secondItem="puU-AL-gPV" secondAttribute="trailing" id="4Wr-tr-pZn"/>
-                <constraint firstAttribute="trailing" secondItem="WR5-rr-22S" secondAttribute="trailing" constant="5" id="8IL-Hs-rCS"/>
+                <constraint firstAttribute="trailing" secondItem="WR5-rr-22S" secondAttribute="trailing" constant="1" id="8IL-Hs-rCS"/>
                 <constraint firstAttribute="bottom" secondItem="puU-AL-gPV" secondAttribute="bottom" constant="2" id="9R4-rG-BJX"/>
                 <constraint firstItem="puU-AL-gPV" firstAttribute="top" secondItem="iN0-l3-epB" secondAttribute="top" constant="2" id="GwY-s4-Vif"/>
-                <constraint firstItem="WR5-rr-22S" firstAttribute="leading" secondItem="UFG-yT-gmg" secondAttribute="trailing" constant="4" id="Ivc-7s-fyb"/>
+                <constraint firstItem="WR5-rr-22S" firstAttribute="leading" secondItem="UFG-yT-gmg" secondAttribute="trailing" id="Ivc-7s-fyb"/>
                 <constraint firstAttribute="bottom" secondItem="UFG-yT-gmg" secondAttribute="bottom" constant="2" id="W1C-Dy-7pX"/>
                 <constraint firstItem="puU-AL-gPV" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="1" id="fP2-Mh-h6I"/>
                 <constraint firstItem="UFG-yT-gmg" firstAttribute="leading" secondItem="puU-AL-gPV" secondAttribute="trailing" id="mBS-KC-Ice"/>

--- a/Pod/Classes/UI/CardView.xib
+++ b/Pod/Classes/UI/CardView.xib
@@ -29,7 +29,7 @@
                 <view clipsSubviews="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="UFG-yT-gmg">
                     <rect key="frame" x="31" y="2" width="538" height="596"/>
                     <subviews>
-                        <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000000000000000" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="T6o-6e-fLS" customClass="NumberInputTextField" customModule="Caishen" customModuleProvider="target">
+                        <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000000000000000" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="T6o-6e-fLS" customClass="NumberInputTextField" customModule="Caishen" customModuleProvider="target">
                             <rect key="frame" x="4" y="0.0" width="538" height="596"/>
                             <accessibility key="accessibilityConfiguration" label="Card Number"/>
                             <fontDescription key="fontDescription" type="system" pointSize="20"/>
@@ -75,7 +75,7 @@
                                         </mask>
                                     </variation>
                                 </textField>
-                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="YY" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CgE-Em-qHJ" customClass="YearInputTextField" customModule="Caishen" customModuleProvider="target">
+                                <textField opaque="NO" clipsSubviews="YES" contentMode="redraw" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="YY" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="CgE-Em-qHJ" customClass="YearInputTextField" customModule="Caishen" customModuleProvider="target">
                                     <rect key="frame" x="272" y="0.0" width="37" height="596"/>
                                     <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                     <accessibility key="accessibilityConfiguration" label="Expiration Year"/>


### PR DESCRIPTION
Implemented different behavior for the card text field when running in Right-to-left language environment.

* Modified view animation to crop the card number to the last four digits when RTL.
* Inverted reading of card type image, card number, month, year, CVC and accessory button when RTL.
* To test this when running on simulator in a left-to-right language, you can do the following:

1. Clone the `Caishen_Example` scheme. 
2. Edit the cloned scheme: `Run ‣ Options ‣ Application Language` - change that to `Right to Left Pseudolanguage`.
3. Run that scheme.

@mohammad19991 