### PR TITLE
Fix for IQKeyboardManager

### DIFF
--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -506,7 +506,13 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     }
     
     public override func becomeFirstResponder() -> Bool {
-        // Return false, since this text view is only for background style purposes
-        return false
+        // Return false if any of this text field's subviews is already first responder. 
+        // Otherwise let `numberInputTextField` become the first responder.
+        if [numberInputTextField,monthTextField,yearTextField,cvcTextField]
+            .flatMap({return $0.isFirstResponder()})
+            .reduce(true, combine: {$0 && $1}) {
+            return false
+        }
+        return numberInputTextField.becomeFirstResponder()
     }
 }

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -515,4 +515,19 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         }
         return numberInputTextField.becomeFirstResponder()
     }
+    
+    public override func isFirstResponder() -> Bool {
+        // Return true if any of `self`'s subviews is the current first responder.
+        return [numberInputTextField,monthTextField,yearTextField,cvcTextField]
+        .filter({$0.isFirstResponder()})
+        .isEmpty == false
+    }
+    
+    public override func resignFirstResponder() -> Bool {
+        // If any of `self`'s subviews is first responder, resign first responder status.
+        return [numberInputTextField,monthTextField,yearTextField,cvcTextField]
+            .filter({$0.isFirstResponder()})
+            .first?
+            .resignFirstResponder() ?? true
+    }
 }


### PR DESCRIPTION
Changed the `becomeFirstResponder` method of `CardNumberTextField` to trigger `becomeFirstResponder` of `numberInputTextField` if none of the subviews are already first responder.

Simply returning `false` here causes IQKeyboardManager to assume that a `CardNumberTextField` shall not be selectable via "Previous" or "Next" button.

Resolves #52 