### PR TITLE
Make validation methods public.

### DIFF
--- a/Pod/Classes/Cards/CardType.swift
+++ b/Pod/Classes/Cards/CardType.swift
@@ -238,7 +238,7 @@ extension CardType {
         - `.NumberTooLong`:             The card number is too long
         - `.NumberDoesNotMatchType`:    The card number's Issuer Identification Number does not match `self`
      */
-    internal func lengthMatchesType(length: Int) -> CardValidationResult {
+    public func lengthMatchesType(length: Int) -> CardValidationResult {
         return testLength(length, assumingLength: expectedCardNumberLength())
     }
 
@@ -250,7 +250,7 @@ extension CardType {
      - returns: `CardValidationResult.Valid` if the card number contains only numeric characters.
         - `.NumberIsNotNumeric`:        Otherwise.
      */
-    internal func numberIsNumeric(number: Number) -> CardValidationResult {
+    public func numberIsNumeric(number: Number) -> CardValidationResult {
         for c in number.description.characters {
             if !["0","1","2","3","4","5","6","7","8","9"].contains(c) {
                 return CardValidationResult.NumberIsNotNumeric


### PR DESCRIPTION
Changed visibility for `numberIsNumeric` and `lengthMatchesType` to make them accessible when creating custom behavior for the card validation.

Resolves #56 .