### PR TITLE
Rename animation methods and change access to public.

### DIFF
--- a/Pod/Classes/UI/CardTextField+PrefillInformation.swift
+++ b/Pod/Classes/UI/CardTextField+PrefillInformation.swift
@@ -46,7 +46,7 @@ public extension CardTextField {
         NSOperationQueue().addOperationWithBlock({
             NSThread.sleepForTimeInterval(0.5)
             NSOperationQueue.mainQueue().addOperationWithBlock({ [weak self] _ in
-                self?.moveNumberFieldLeftAnimated()
+                self?.moveCardNumberOutAnimated()
             })
         })
         

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -46,6 +46,7 @@ public extension CardTextField {
         }
         numberInputTextField?.resignFirstResponder()
         cardInfoView?.transform = CGAffineTransformIdentity
+        monthTextField.becomeFirstResponder()
     }
     
     /**
@@ -56,6 +57,7 @@ public extension CardTextField {
         infoTextFields.forEach({$0?.resignFirstResponder()})
         numberInputTextField?.transform = CGAffineTransformIdentity
         numberInputTextField?.alpha = 1
+        numberInputTextField.becomeFirstResponder()
         cardInfoView?.transform = CGAffineTransformMakeTranslation(superview!.bounds.width, 0)
     }
 }

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -14,25 +14,25 @@ public extension CardTextField {
     /**
      Moves the card number input field to the left outside of the screen with an animation of the duration `viewAnimationDuration`, so that only the last group of the card number is visible. At the same time, the card detail (expiration month and year and CVC) slide in from the right.
      */
-    internal func moveNumberFieldLeftAnimated() {
+    public func moveCardNumberOutAnimated() {
         UIView.animateWithDuration(viewAnimationDuration, animations: { [weak self] _ in
-            self?.moveNumberFieldLeft()
+            self?.moveCardNumberOut()
             })
     }
     
     /**
      Moves the full card number input field to inside the screen with an animation of the duration `viewAnimationDuration`. At the same time, the card detail (expiration month and year and CVC) slide outside the view.
      */
-    internal func moveNumberFieldRightAnimated() {
+    public func moveCardNumberInAnimated() {
         UIView.animateWithDuration(viewAnimationDuration, animations: { [weak self] _ in
-            self?.moveNumberFieldRight()
+            self?.moveCardNumberIn()
             })
     }
     
     /**
      Moves the card number input field to the left outside of the screen, so that only the last group of the card number is visible. At the same time, the card detail (expiration month and year and CVC) are displayed to its right.
      */
-    internal func moveNumberFieldLeft() {
+    public func moveCardNumberOut() {
         // If the card number is invalid, do not allow to move to the card detail
         if cardType?.validateNumber(card.bankCardNumber) != .Valid {
             return
@@ -51,7 +51,7 @@ public extension CardTextField {
     /**
      Moves the full card number input field to inside the screen. At the same time, the card detail (expiration month and year and CVC) are moved outside the view.
      */
-    internal func moveNumberFieldRight() {
+    public func moveCardNumberIn() {
         let infoTextFields: [UITextField?] = [monthTextField, yearTextField, cvcTextField]
         infoTextFields.forEach({$0?.resignFirstResponder()})
         numberInputTextField?.transform = CGAffineTransformIdentity

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -248,12 +248,12 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         accessoryButtonLeadingConstraint?.constant = accessoryButtonLeadingInset
         accessoryButtonTrailingConstraint?.constant = accessoryButtonTrailingInset
         
-        let leftSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveNumberFieldLeftAnimated))
+        let leftSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberOutAnimated))
         leftSwipeGestureRecognizer.direction = .Left
         firstObjectInNib.addGestureRecognizer(leftSwipeGestureRecognizer)
         
         [firstObjectInNib, cardInfoView].forEach({
-            let rightSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveNumberFieldRightAnimated))
+            let rightSwipeGestureRecognizer = UISwipeGestureRecognizer(target: self, action: #selector(moveCardNumberInAnimated))
             rightSwipeGestureRecognizer.direction = .Right
             $0?.addGestureRecognizer(rightSwipeGestureRecognizer)
         })
@@ -321,7 +321,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
      */
     private func setupTargetsForEditinBegin() {
         // Show the full number text field, if editing began on it
-        numberInputTextField?.addTarget(self, action: #selector(moveNumberFieldRightAnimated), forControlEvents: UIControlEvents.EditingDidBegin)
+        numberInputTextField?.addTarget(self, action: #selector(moveCardNumberInAnimated), forControlEvents: UIControlEvents.EditingDidBegin)
         
         // Show CVC image if the cvcTextField is selected, show card image otherwise
         let nonCVCTextFields: [UITextField?] = [numberInputTextField, monthTextField, yearTextField]
@@ -373,7 +373,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
     public override func didMoveToSuperview() {
         super.didMoveToSuperview()
-        moveNumberFieldRight()
+        moveCardNumberIn()
     }
     
     // MARK: - View customization
@@ -419,7 +419,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     }
     
     public func numberInputTextFieldDidComplete(CardTextField: NumberInputTextField) {
-        moveNumberFieldLeftAnimated()
+        moveCardNumberOutAnimated()
         
         notifyDelegate()
         monthTextField?.becomeFirstResponder()
@@ -455,7 +455,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         
         // If moving to a larger screen size and not showing the detail view, make sure that it is outside the view.
         if let transform = cardInfoView?.transform where !CGAffineTransformIsIdentity(transform) {
-            moveNumberFieldRight()
+            moveCardNumberIn()
         }
     }
     


### PR DESCRIPTION
Renamed the animation methods to be more descriptive and changed the access to `public` in order to let developers manually call these methods when desired.

Resolves #55