### PR TITLE
Change integration of `CardTypeRegister`

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - Caishen (1.1.0)
+  - Caishen (1.2.1)
   - CardIO (5.3.2)
 
 DEPENDENCIES:
@@ -11,7 +11,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Caishen: bdf3a453cc00f3113702407645b414f3abe59909
+  Caishen: a79d5b184b460828a32a73ba8ba439d59720a764
   CardIO: 92c45caef0d986c4a303a7afba0c9b76ff2b1f6e
 
 COCOAPODS: 0.39.0

--- a/Pod/Classes/Cards/CardTypeRegister.swift
+++ b/Pod/Classes/Cards/CardTypeRegister.swift
@@ -14,22 +14,30 @@ public class CardTypeRegister {
     /**
      The default card type register, shared among all CardTextFields.
      */
-    public static let sharedCardTypeRegister = CardTypeRegister()
+    public static let sharedCardTypeRegister = CardTypeRegister(registeredCardTypes: CardTypeRegister.defaultCardTypes)
     
     /// An array of all registered card types. You can edit this array with `registerCardType`, `unregisterCardType` or `setRegisteredCardTypes`.
     public private(set) var registeredCardTypes: [CardType]
     
     /**
-     Creates a new `CardTypeRegister` with the following card types:
-     - AmericanExpress
-     - DinersClub
-     - Discover
-     - JCB
-     - MasterCard
-     - Visa
+     Creates a new `CardTypeRegister` that accepts no card types.
      */
-    init() {
-        registeredCardTypes = [
+    public init() {
+        registeredCardTypes = []
+    }
+
+    /**
+     Creates a new `CardTypeRegister` with the given sequence of card types.
+     
+     - parameter registeredCardTypes: Any sequence of `CardType` that should be accepted by `self`.
+     */
+    public convenience init<T: SequenceType where T.Generator.Element == CardType>(registeredCardTypes: T) {
+        self.init()
+        setRegisteredCardTypes(registeredCardTypes)
+    }
+
+    /// An array with the default card types provided by Caishen.
+    public static let defaultCardTypes: [CardType] = [
             AmericanExpress(),
             ChinaUnionPay(),
             DinersClub(),
@@ -38,7 +46,6 @@ public class CardTypeRegister {
             MasterCard(),
             Visa()
         ]
-    }
     
     /**
      Adds the provided card type to the array of registered card types.

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -170,7 +170,11 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
      This card type register contains a list of all valid card types. You can provide separate card type registers for different card number text fields.
      By default, CardTypeRegister.sharedCardTypeRegister is used.
      */
-    public var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister
+    public var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister {
+        didSet {
+            numberInputTextField.cardTypeRegister = cardTypeRegister
+        }
+    }
 
     #if !TARGET_INTERFACE_BUILDER
     public override var placeholder: String? {

--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -94,11 +94,10 @@ public class NumberInputTextField: StylizedTextField {
         }
     }
 
-    
     /**
      The card type register that holds information about which card types are accepted and which ones are not.
      */
-    private let cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister
+    public var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister
     
     /**
      A card number formatter used to format the input


### PR DESCRIPTION
Added public set with the default card types that are accepted by newly created cardTextFields. Made constructor of `CardTypeRegister` public in order to allow the creation of new registers when handling multiple card text fields.

Resolves #60