### PR TITLE
Add option to disable expiry and/or cvc for specific card types

### DIFF
--- a/Pod/Classes/Cards/CardType.swift
+++ b/Pod/Classes/Cards/CardType.swift
@@ -61,6 +61,20 @@ public protocol CardType {
      */
     func validateCVC(cvc: CVC) -> CardValidationResult
 
+    
+    /** 
+     A boolean flag that indicates whether CVC validation is required for this card type or not.
+     Setting this value to false will hide the CVC text field from the `CardTextField` and remove the required validation routine.
+     */
+    var requiresCVC: Bool { get }
+
+    /**
+     A boolean flag that indicates whether expiry validation is required for this card type or not.
+     Setting this value to false will hide the month and year text field from the `CardTextField` and remove the required
+     validation routine.
+     */
+    var requiresExpiry: Bool { get }
+
     /**
      Validates the card number.
      
@@ -96,6 +110,14 @@ extension CardType {
     public func isEqualTo(cardType: CardType) -> Bool {
         return cardType.name == self.name
     }
+    
+    public var requiresExpiry: Bool {
+        return true
+    }
+    
+    public var requiresCVC: Bool {
+        return true
+    }
 
     public var numberGrouping: [Int] {
         return [4, 4, 4, 4]
@@ -106,6 +128,11 @@ extension CardType {
     }
 
     public func validateCVC(cvc: CVC) -> CardValidationResult {
+
+        guard requiresCVC else {
+            return .Valid
+        }
+
         guard let _ = cvc.toInt() else {
             return .InvalidCVC
         }
@@ -126,6 +153,10 @@ extension CardType {
     }
 
     public func validateExpiry(expiry: Expiry) -> CardValidationResult {
+        guard requiresExpiry else {
+            return .Valid
+        }
+        
         guard expiry != Expiry.invalid else {
             return .InvalidExpiry
         }

--- a/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
+++ b/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
@@ -31,9 +31,15 @@ extension CardTextField: CardInfoTextFieldDelegate {
     private func selectNextTextField(textField: UITextField, prefillText: String?) {
         var nextTextField: UITextField?
         if textField == monthTextField {
-            nextTextField = yearTextField
+            if hideExpiryTextFields {
+                selectNextTextField(yearTextField, prefillText: prefillText)
+            } else {
+                nextTextField = yearTextField
+            }
         } else if textField == yearTextField {
-            nextTextField = cvcTextField
+            if !hideCVCTextField {
+                nextTextField = cvcTextField
+            }
         }
 
         nextTextField?.becomeFirstResponder()

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -37,6 +37,10 @@ public extension CardTextField {
         if cardType?.validateNumber(card.bankCardNumber) != .Valid {
             return
         }
+        // If neither expiry nor cvc are required, also do not allow to move to the detail
+        if hideExpiryTextFields && hideCVCTextField {
+            return
+        }
         // We will set numberInputTextField as first responder in the next step. This will trigger `editingDidBegin`
         // which in turn will cause the number field to move to full display. This can cause animation issues.
         // In order to tackle these animation issues, check if the cardInfoView was previously fully displayed (and should therefor not be moved with an animation).


### PR DESCRIPTION
This will not trigger the view animation that happens for a completed card number when requiring neither cvc nor expiry. If only one of them is required, the other one will be hidden.

Resolves #59