### PR TITLE
Bug/card number first responder changes

### DIFF
--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -90,7 +90,6 @@ public extension CardTextField {
      */
     public func moveCardNumberIn() {
         let infoTextFields: [UITextField?] = [monthTextField, yearTextField, cvcTextField]
-        infoTextFields.forEach({$0?.resignFirstResponder()})
         if isRightToLeftLanguage {
             UIView.performWithoutAnimation {
                 self.numberInputTextField?.alpha = 1
@@ -122,10 +121,12 @@ public extension CardTextField {
                 DISPATCH_TIME_NOW,
                 Int64(firstResponderDelay * Double(NSEC_PER_SEC))),
                            dispatch_get_main_queue()) {
+                            infoTextFields.forEach({$0?.resignFirstResponder()})
                             self.numberInputTextField.becomeFirstResponder()
             }
         } else {
             numberInputTextField?.layer.mask = nil
+            infoTextFields.forEach({$0?.resignFirstResponder()})
             numberInputTextField.becomeFirstResponder()
         }
     }

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -114,14 +114,19 @@ public extension CardTextField {
                            dispatch_get_main_queue()) { [weak self] _ in
                 self?.numberInputTextField?.layer.mask = nil
             }
+            
+            // Let the number text field become first responder only after the animation has completed (left to right script)
+            // or half way through the view animation (right to left script)
+            let firstResponderDelay = isRightToLeftLanguage ? viewAnimationDuration / 2.0 : viewAnimationDuration
+            dispatch_after(dispatch_time(
+                DISPATCH_TIME_NOW,
+                Int64(firstResponderDelay * Double(NSEC_PER_SEC))),
+                           dispatch_get_main_queue()) {
+                            self.numberInputTextField.becomeFirstResponder()
+            }
         } else {
             numberInputTextField?.layer.mask = nil
-        }
-        
-        if isRightToLeftLanguage {
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(viewAnimationDuration / 2.0 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()){
-                self.numberInputTextField.becomeFirstResponder()
-            }
+            numberInputTextField.becomeFirstResponder()
         }
     }
 }

--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -90,19 +90,8 @@ public extension CardTextField {
      */
     public func moveCardNumberIn() {
         let infoTextFields: [UITextField?] = [monthTextField, yearTextField, cvcTextField]
-        if isRightToLeftLanguage {
-            UIView.performWithoutAnimation {
-                self.numberInputTextField?.alpha = 1
-                self.numberInputTextField?.transform = CGAffineTransformIdentity
-            }
-        } else {
-            numberInputTextField?.alpha = 1
-            numberInputTextField?.transform = CGAffineTransformIdentity
-        }
         
-        // Move card info view
-        let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
-        cardInfoView?.transform = CGAffineTransformMakeTranslation(offset, 0)
+        translateCardNumberIn()
         
         // If card info view is moved with an animation, wait for it to finish before
         // showing the full card number to avoid overlapping on RTL language.
@@ -129,5 +118,21 @@ public extension CardTextField {
             infoTextFields.forEach({$0?.resignFirstResponder()})
             numberInputTextField.becomeFirstResponder()
         }
+    }
+    
+    internal func translateCardNumberIn() {
+        if isRightToLeftLanguage {
+            UIView.performWithoutAnimation {
+                self.numberInputTextField?.alpha = 1
+                self.numberInputTextField?.transform = CGAffineTransformIdentity
+            }
+        } else {
+            numberInputTextField?.alpha = 1
+            numberInputTextField?.transform = CGAffineTransformIdentity
+        }
+        
+        // Move card info view
+        let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
+        cardInfoView?.transform = CGAffineTransformMakeTranslation(offset, 0)
     }
 }

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -410,7 +410,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
     public override func didMoveToSuperview() {
         super.didMoveToSuperview()
-        moveCardNumberIn()
+        translateCardNumberIn()
     }
     
     // MARK: - View customization
@@ -492,7 +492,7 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
         
         // If moving to a larger screen size and not showing the detail view, make sure that it is outside the view.
         if let transform = cardInfoView?.transform where !CGAffineTransformIsIdentity(transform) {
-            moveCardNumberIn()
+            translateCardNumberIn()
         }
     }
     


### PR DESCRIPTION
This PR changes the behavior towards becoming first responder.

* Fixed the text field to no longer become first responder on view layout changes or after moving to superview
* Delayed `becomeFirstResponder` on `numberInputTextField` to be called only after the view animation has completed (LTR script)
* The reason we want the number input text field to become first responder after moving the card number in (therefor the reason for this PR) is to keep the focus on the text field after performing a swipe gesture. Otherwise, users would have to perform a swipe gesture to move to the number text field and tap on it again to make changes to the card number.