### PR TITLE
Changed the offset to move the card info view out of sight

### DIFF
--- a/Pod/Classes/UI/CardTextField+ViewAnimations.swift
+++ b/Pod/Classes/UI/CardTextField+ViewAnimations.swift
@@ -132,7 +132,7 @@ public extension CardTextField {
         }
         
         // Move card info view
-        let offset = isRightToLeftLanguage ? -superview!.bounds.width : superview!.bounds.width
+        let offset = isRightToLeftLanguage ? -bounds.width : bounds.width
         cardInfoView?.transform = CGAffineTransformMakeTranslation(offset, 0)
     }
 }


### PR DESCRIPTION
* This removes force unwrap of `superview` in favor of just using the text fields own bounds

Resolves #66 