### PR TITLE
Added ability to use separate components of Caishen

### DIFF
--- a/Pod/Classes/Cards/Card.swift
+++ b/Pod/Classes/Cards/Card.swift
@@ -56,7 +56,7 @@ public struct Card {
      - parameter cardVerificationCode: The card verification code as indicated on the user's payment card.
      - parameter expiryDate: The expiration date as indicated on the user's payment card
     */
-    internal init(bankCardNumber: Number, cardVerificationCode: CVC, expiryDate: Expiry) {
+    public init(bankCardNumber: Number, cardVerificationCode: CVC, expiryDate: Expiry) {
         self.bankCardNumber = bankCardNumber
         self.cardVerificationCode = cardVerificationCode
         self.expiryDate = expiryDate

--- a/Pod/Classes/Cards/Default Card Types/UnknownCardType.swift
+++ b/Pod/Classes/Cards/Default Card Types/UnknownCardType.swift
@@ -9,24 +9,24 @@
 /**
  *  The undefined card type
  */
-internal struct UnknownCardType: CardType {
+public struct UnknownCardType: CardType {
 
-    let name = "Unknown"
-    let CVCLength = 0
-    let identifyingDigits: Set<Int> = []
+    public let name = "Unknown"
+    public let CVCLength = 0
+    public let identifyingDigits: Set<Int> = []
 
-    func validateNumber(cardNumber: Number) -> CardValidationResult {
+    public func validateNumber(cardNumber: Number) -> CardValidationResult {
         return CardValidationResult.UnknownType
             .union(lengthMatchesType(cardNumber.length))
             .union(numberIsNumeric(cardNumber))
             .union(numberIsValidLuhn(cardNumber))
     }
 
-    func validateCVC(cvc: CVC) -> CardValidationResult {
+    public func validateCVC(cvc: CVC) -> CardValidationResult {
         return .UnknownType
     }
 
-    func validateExpiry(expiry: Expiry) -> CardValidationResult {
+    public func validateExpiry(expiry: Expiry) -> CardValidationResult {
         return .UnknownType
     }
 

--- a/Pod/Classes/Cards/Expiry.swift
+++ b/Pod/Classes/Cards/Expiry.swift
@@ -16,7 +16,7 @@ private let gregorianCalendar = NSCalendar(calendarIdentifier: NSCalendarIdentif
 public struct Expiry: RawRepresentable {
 
     /// An invalid expiry date. This date is set to 1/1/1970 and therefor will be shown as `expired`.
-    static let invalid = Expiry(rawValue: NSDate(timeIntervalSince1970: 0))
+    public static let invalid = Expiry(rawValue: NSDate(timeIntervalSince1970: 0))
 
     public typealias RawValue = NSDate
 

--- a/Pod/Classes/UI/Text Fields/CVCInputTextField.swift
+++ b/Pod/Classes/UI/Text Fields/CVCInputTextField.swift
@@ -12,7 +12,7 @@ import UIKit
 public class CVCInputTextField: DetailInputTextField {
     
     /// The card type for the CVC that should be entered. The length of a CVC can vary based on this card type.
-    var cardType: CardType?
+    public var cardType: CardType?
     override var expectedInputLength: Int {
         return cardType?.CVCLength ?? 3
     }

--- a/Pod/Classes/UI/Text Fields/DetailInputTextField.swift
+++ b/Pod/Classes/UI/Text Fields/DetailInputTextField.swift
@@ -15,7 +15,7 @@ import UIKit
  */
 public class DetailInputTextField: StylizedTextField {
     
-    var cardInfoTextFieldDelegate: CardInfoTextFieldDelegate?
+    public var cardInfoTextFieldDelegate: CardInfoTextFieldDelegate?
     
     public func textFieldDidBeginEditing(textField: UITextField) {
         if (textField.text ?? "").isEmpty {

--- a/README.md
+++ b/README.md
@@ -110,90 +110,6 @@ Additionally, CardTextField offers attributes tailored to its purpose (accessibl
 
 ---
 
-### Using the different components of the text field separately
-
-Instead of entering the card number, expiry and CVC in a single text field, it is possible to use single text fields to enter this information separately.
-
-```swift
-class ViewController: UIViewController, NumberInputTextFieldDelegate, CardInfoTextFieldDelegate {
-    
-    @IBOutlet weak var cardNumberTextField: NumberInputTextField!
-    @IBOutlet weak var monthInputTextField: MonthInputTextField!
-    @IBOutlet weak var yearInputTextField: YearInputTextField!
-    @IBOutlet weak var cvcInputTextField: CVCInputTextField!
-        
-    // A card that is not nil when valid information has been entered in the text fields:
-    var card: Card? {
-        let number = cardNumberTextField.cardNumber
-        let cvc = CVC(rawValue: cvcInputTextField.text ?? "")
-        let expiry = Expiry(month: monthInputTextField.text ?? "", year: yearInputTextField.text ?? "")
-                        ?? Expiry.invalid
-        
-        let cardType = cardNumberTextField.cardTypeRegister.cardTypeForNumber(cardNumberTextField.cardNumber)
-        if cardType.validateCVC(cvc).union(cardType.validateExpiry(expiry)).union(cardType.validateNumber(number)) == .Valid {
-            return Card(bankCardNumber: number, cardVerificationCode: cvc, expiryDate: expiry)
-        } else {
-            return nil
-        }
-    }
-    
-    override func viewDidLoad() {
-        super.viewDidLoad()
-        
-        cardNumberTextField.numberInputTextFieldDelegate = self
-        monthInputTextField.cardInfoTextFieldDelegate = self
-        yearInputTextField.cardInfoTextFieldDelegate = self
-        cvcInputTextField.cardInfoTextFieldDelegate = self
-        
-        // Set the `deleteBackwardCallbacks` - closures which are called whenever a user hits
-        // backspace on an empty text field.
-        monthInputTextField.deleteBackwardCallback = { _ in self.cardNumberTextField.becomeFirstResponder() }
-        yearInputTextField.deleteBackwardCallback = { _ in self.monthInputTextField.becomeFirstResponder() }
-        cvcInputTextField.deleteBackwardCallback = { _ in self.yearInputTextField.becomeFirstResponder() }
-    }
-    
-    func numberInputTextFieldDidComplete(numberInputTextField: NumberInputTextField) {
-        cvcInputTextField.cardType = numberInputTextField.cardTypeRegister.cardTypeForNumber(numberInputTextField.cardNumber)
-        print("Card number: \(numberInputTextField.cardNumber)")
-        print(card)
-        monthInputTextField.becomeFirstResponder()
-    }
-    
-    func numberInputTextFieldDidChangeText(numberInputTextField: NumberInputTextField) {
-        
-    }
-    
-    func textField(textField: UITextField, didEnterValidInfo: String) {
-        switch textField {
-        case is MonthInputTextField:
-            print("Month: \(didEnterValidInfo)")
-            yearInputTextField.becomeFirstResponder()
-        case is YearInputTextField:
-            print("Year: \(didEnterValidInfo)")
-            cvcInputTextField.becomeFirstResponder()
-        case is CVCInputTextField:
-            print("CVC: \(didEnterValidInfo)")
-        default:
-            break
-        }
-        print(card)
-    }
-    
-    func textField(textField: UITextField, didEnterPartiallyValidInfo: String) {
-        // The user entered information that is not valid but might become valid on further input.
-        // Example: Entering "1" for the CVC is partially valid, while entering "a" is not.
-    }
-    
-    func textField(textField: UITextField, didEnterOverflowInfo overFlowDigits: String) {
-        // This function is used in a CardTextField to carry digits to the next text field.
-        // Example: A user entered "02/20" as expiry and now tries to append "5" to the month.
-        //          On a card text field, the year will be replaced with "5" - the overflow digit.
-    }
-    
-    // ...
-}
-```
-
 ### CardIO
 
 CardIO might be among the most powerful tools to let users enter their payment card information. It uses the camera and lets the user scan his or her credit card. However, you might still want to provide users with a visually appealing text field to enter their payment card information, since users might want to restrict access to their camera or simply want to enter this information manually.
@@ -295,6 +211,92 @@ class MyViewController: UIViewController, CardTextFieldDelegate {
 	}
 	
 	...
+}
+```
+
+---
+
+### Using the different components of the text field separately
+
+Instead of entering the card number, expiry and CVC in a single text field, it is possible to use single text fields to enter this information separately.
+
+```swift
+class ViewController: UIViewController, NumberInputTextFieldDelegate, CardInfoTextFieldDelegate {
+    
+    @IBOutlet weak var cardNumberTextField: NumberInputTextField!
+    @IBOutlet weak var monthInputTextField: MonthInputTextField!
+    @IBOutlet weak var yearInputTextField: YearInputTextField!
+    @IBOutlet weak var cvcInputTextField: CVCInputTextField!
+        
+    // A card that is not nil when valid information has been entered in the text fields:
+    var card: Card? {
+        let number = cardNumberTextField.cardNumber
+        let cvc = CVC(rawValue: cvcInputTextField.text ?? "")
+        let expiry = Expiry(month: monthInputTextField.text ?? "", year: yearInputTextField.text ?? "")
+                        ?? Expiry.invalid
+        
+        let cardType = cardNumberTextField.cardTypeRegister.cardTypeForNumber(cardNumberTextField.cardNumber)
+        if cardType.validateCVC(cvc).union(cardType.validateExpiry(expiry)).union(cardType.validateNumber(number)) == .Valid {
+            return Card(bankCardNumber: number, cardVerificationCode: cvc, expiryDate: expiry)
+        } else {
+            return nil
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        cardNumberTextField.numberInputTextFieldDelegate = self
+        monthInputTextField.cardInfoTextFieldDelegate = self
+        yearInputTextField.cardInfoTextFieldDelegate = self
+        cvcInputTextField.cardInfoTextFieldDelegate = self
+        
+        // Set the `deleteBackwardCallbacks` - closures which are called whenever a user hits
+        // backspace on an empty text field.
+        monthInputTextField.deleteBackwardCallback = { _ in self.cardNumberTextField.becomeFirstResponder() }
+        yearInputTextField.deleteBackwardCallback = { _ in self.monthInputTextField.becomeFirstResponder() }
+        cvcInputTextField.deleteBackwardCallback = { _ in self.yearInputTextField.becomeFirstResponder() }
+    }
+    
+    func numberInputTextFieldDidComplete(numberInputTextField: NumberInputTextField) {
+        cvcInputTextField.cardType = numberInputTextField.cardTypeRegister.cardTypeForNumber(numberInputTextField.cardNumber)
+        print("Card number: \(numberInputTextField.cardNumber)")
+        print(card)
+        monthInputTextField.becomeFirstResponder()
+    }
+    
+    func numberInputTextFieldDidChangeText(numberInputTextField: NumberInputTextField) {
+        
+    }
+    
+    func textField(textField: UITextField, didEnterValidInfo: String) {
+        switch textField {
+        case is MonthInputTextField:
+            print("Month: \(didEnterValidInfo)")
+            yearInputTextField.becomeFirstResponder()
+        case is YearInputTextField:
+            print("Year: \(didEnterValidInfo)")
+            cvcInputTextField.becomeFirstResponder()
+        case is CVCInputTextField:
+            print("CVC: \(didEnterValidInfo)")
+        default:
+            break
+        }
+        print(card)
+    }
+    
+    func textField(textField: UITextField, didEnterPartiallyValidInfo: String) {
+        // The user entered information that is not valid but might become valid on further input.
+        // Example: Entering "1" for the CVC is partially valid, while entering "a" is not.
+    }
+    
+    func textField(textField: UITextField, didEnterOverflowInfo overFlowDigits: String) {
+        // This function is used in a CardTextField to carry digits to the next text field.
+        // Example: A user entered "02/20" as expiry and now tries to append "5" to the month.
+        //          On a card text field, the year will be replaced with "5" - the overflow digit.
+    }
+    
+    // ...
 }
 ```
 


### PR DESCRIPTION
* Changed access level of `Card.init`, `Expiry.invalid`, `CVCInputTextField.cardType` and `DetailInputTextField.cardIntoTextFieldDelegate` in order to make them accessible when using these properties outside of Caishen.
* Added section in Readme that shows a (very basic) example of how to implement the different components of Caishen 

This closes #68 