### PR TITLE
Fixed crash when setting a non-numerical placeholder.

### DIFF
--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -44,11 +44,12 @@ public class NumberInputTextField: StylizedTextField {
             guard let placeholder = placeholder else {
                 return
             }
-
+            
             let isUnformatted = (placeholder == self.cardNumberFormatter.unformattedCardNumber(placeholder))
-        
-            // Format the placeholder, if not already done
-            if isUnformatted && cardNumberSeparator != "" {
+            let isCreditString = (placeholder.rangeOfCharacterFromSet(NSCharacterSet(charactersInString: "0123456789\(self.cardNumberFormatter.separator)").invertedSet) == nil)
+            
+            // If this is a Credit Card placeholder and wasn't already formatted, format it
+            if isCreditString && isUnformatted && cardNumberSeparator != "" {
                 self.placeholder = cardNumberFormatter.formattedCardNumber(placeholder)
             }
         }


### PR DESCRIPTION
Setting a non-numerical placeholder (e.g. non Credit Card) such as "Type in your credit card" or "Credit card number" will crash.

This fix validates the string contains only characters that are between 0-9, as well as `CardNumberFormatter().separator`