### PR TITLE
Implemented crash fix for IBInspectable engine in CardTextField

### DIFF
--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -597,9 +597,15 @@ public class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
     public override func isFirstResponder() -> Bool {
         // Return true if any of `self`'s subviews is the current first responder.
-        return [numberInputTextField,monthTextField,yearTextField,cvcTextField]
-        .filter({$0.isFirstResponder()})
-        .isEmpty == false
+        // Needs to unwrap the IBOutlets otherwise IBInspectable is crashing when using CardTextField because IBOutlets
+        // are not initialized yet when IBInspectable engine runs.
+        guard let numberInputTextField = numberInputTextField, monthTextField = monthTextField, yearTextField = yearTextField, cvcTextField = cvcTextField else {
+            return false
+        }
+
+        return [numberInputTextField, monthTextField, yearTextField, cvcTextField]
+            .filter({$0.isFirstResponder()})
+            .isEmpty == false
     }
     
     public override func resignFirstResponder() -> Bool {


### PR DESCRIPTION
I noticed an Interface Builder crash due to IBInspectable. After looking at the logs, it mentioned that optional nil value wasn't unwrapped.

Based on this [post](http://stackoverflow.com/a/37257488), I ran the debug tool from Interface Builder and had a crash where I fixed the code. Unwrapping the IBOutlets used in this function is fixing my issue.

As a reference here is the screenshot of the error I encountered:

<img width="246" alt="screen shot 2016-08-02 at 12 51 57 pm" src="https://cloud.githubusercontent.com/assets/6641355/17328911/7130db54-58c0-11e6-814d-6a88347fdfc3.png">
