### PR TITLE
Make CardInfoTextFieldDelegate Obj-C convertible

### DIFF
--- a/Pod/Classes/UI/Text Fields/Delegates/CardInfoTextFieldDelegate.swift
+++ b/Pod/Classes/UI/Text Fields/Delegates/CardInfoTextFieldDelegate.swift
@@ -11,6 +11,7 @@ import UIKit
 /**
  A protocol for the delegate of a `DetailInputTextField`.
  */
+@objc
 public protocol CardInfoTextFieldDelegate {
     
     /**


### PR DESCRIPTION
Allow CardInfoTextFieldDelegate to be of type `Protocol` as it's done for `NumberInputTextFieldDelegate`