### PR TITLE
Allow to redraw placeholder after initial drawing

### DIFF
--- a/Pod/Classes/UI/StylizedTextField.swift
+++ b/Pod/Classes/UI/StylizedTextField.swift
@@ -84,6 +84,12 @@ public class StylizedTextField: UITextField, UITextFieldDelegate {
     }
     
     // MARK: - Override functions
+
+    public override var placeholder: String? {
+        didSet {
+            setNeedsDisplay()
+        }
+    }
     
     override public func becomeFirstResponder() -> Bool {
         UIAccessibilityPostNotification(UIAccessibilityScreenChangedNotification, self)


### PR DESCRIPTION
Currently, I encountered an issue where placeholder changed as it's expected if you specifically don't call `setNeedsDisplay()`, so the PR fixes the issue