### PR TITLE
Fixed an issue where calling `prefillInformation` on `NumberInputTextField` would set a wrong text color

### DIFF
--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -171,9 +171,10 @@ public class NumberInputTextField: StylizedTextField {
         let numberPartiallyValid = type.checkCardNumberPartiallyValid(cardNumber) == .Valid
         
         if numberPartiallyValid {
-            let formatter = cardNumberFormatter
-            text = formatter.formattedCardNumber(unformattedCardNumber)
-            numberInputTextFieldDelegate?.numberInputTextFieldDidChangeText(self)
+            // Set text and apply text color changes if the prefilled card type is unknown
+            textField(self,
+                      shouldChangeCharactersInRange: NSRange(location: 0, length: text?.characters.count ?? 0),
+                      replacementString: cardNumber.rawValue)
         }
     }
     


### PR DESCRIPTION
These changes treat pre-filling a card number like manually entering one, therefor correctly adjusting text color and notifying a `NumberInputTextField`'s delegate about text changes.

Fixes #80
