### PR TITLE
Removed automated formatting of placeholder text to avoid crashes

### DIFF
--- a/Example/Caishen/Base.lproj/Main.storyboard
+++ b/Example/Caishen/Base.lproj/Main.storyboard
@@ -99,7 +99,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000000000000000" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xhV-mK-kcC" customClass="CardTextField" customModule="Caishen">
+                                        <textField opaque="NO" clipsSubviews="YES" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" placeholder="0000 - 0000 - 0000 - 0000" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="xhV-mK-kcC" customClass="CardTextField" customModule="Caishen">
                                             <rect key="frame" x="170" y="292" width="260" height="17"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             <constraints>

--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -33,27 +33,7 @@ public class NumberInputTextField: StylizedTextField {
     /**
      The string that is used to separate different groups in a card number.
      */
-    @IBInspectable public var cardNumberSeparator: String = "-" {
-        didSet {
-            placeholder = cardNumberFormatter.formattedCardNumber(self.placeholder ?? "1234123412341234")
-        }
-    }
-
-    override public var placeholder: String? {
-        didSet {
-            guard let placeholder = placeholder else {
-                return
-            }
-            
-            let isUnformatted = (placeholder == self.cardNumberFormatter.unformattedCardNumber(placeholder))
-            let isCreditString = (placeholder.rangeOfCharacterFromSet(NSCharacterSet(charactersInString: "0123456789\(self.cardNumberFormatter.separator)").invertedSet) == nil)
-            
-            // If this is a Credit Card placeholder and wasn't already formatted, format it
-            if isCreditString && isUnformatted && cardNumberSeparator != "" {
-                self.placeholder = cardNumberFormatter.formattedCardNumber(placeholder)
-            }
-        }
-    }
+    @IBInspectable public var cardNumberSeparator: String = "-"
     
     public override var accessibilityValue: String? {
         get {

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ CardTextField is mostly customizable like every other UITextField. Setting any o
 
 | Property           | Type                 | Description                                                                                                            |
 |:-------------------|:---------------------|:-----------------------------------------------------------------------------------------------------------------------|
-| placeholder        | String?              | The card number place holder. This will be automatically formatted at runtime to look like an actual Visa card number. |
+| placeholder        | String?              | The card number place holder. When using a card number as placeholder, make sure to format it appropriately so it uses the `cardNumberSeparator` that has been set for the text field (i.e. when using " - " as separator, set a placeholder like "1234 - 1234 - 1234 - 1234"). |
 | textColor          | UIColor?             | The color of text entered into the CardTextField.                                                                |
 | backgroundColor    | UIColor?             | The background color of the text field.                                                                                |
 | font               | UIFont?              | The font of the entered text.                                                                                          |


### PR DESCRIPTION
Fixes #95 

This removes formatting numeric placeholders (such as 4321432143214321 to 4321 4321 4321 4321) which can currently cause runtime crashes. Doing this on the user side most likely makes more sense (giving user full control about what to format in which way) and removing it might make the Pod itself more stable and easier to maintain.