### PR TITLE
Opened up variables and functions

### DIFF
--- a/Pod/Classes/Cards/CardTypeRegister.swift
+++ b/Pod/Classes/Cards/CardTypeRegister.swift
@@ -14,10 +14,10 @@ open class CardTypeRegister {
     /**
      The default card type register, shared among all CardTextFields.
      */
-    public static let sharedCardTypeRegister = CardTypeRegister(registeredCardTypes: CardTypeRegister.defaultCardTypes)
+    open static let sharedCardTypeRegister = CardTypeRegister(registeredCardTypes: CardTypeRegister.defaultCardTypes)
     
     /// An array of all registered card types. You can edit this array with `registerCardType`, `unregisterCardType` or `setRegisteredCardTypes`.
-    public private(set) var registeredCardTypes: [CardType]
+    open private(set) var registeredCardTypes: [CardType]
     
     /**
      Creates a new `CardTypeRegister` that accepts no card types.
@@ -37,7 +37,7 @@ open class CardTypeRegister {
     }
 
     /// An array with the default card types provided by Caishen.
-    public static let defaultCardTypes: [CardType] = [
+    open static let defaultCardTypes: [CardType] = [
             AmericanExpress(),
             ChinaUnionPay(),
             DinersClub(),
@@ -52,7 +52,7 @@ open class CardTypeRegister {
      
      - parameter cardType: The card type that should be contained in this card type register.
      */
-    public func register(cardType: CardType) {
+    open func register(cardType: CardType) {
         if registeredCardTypes.contains(where: { $0.isEqual(to: cardType) }) {
             return
         }
@@ -65,7 +65,7 @@ open class CardTypeRegister {
      
      - parameter cardType: The card type that should be removed from this card type register.
      */
-    public func unregister(cardType: CardType) {
+    open func unregister(cardType: CardType) {
         registeredCardTypes = registeredCardTypes.filter { !$0.isEqual(to: cardType) }
     }
     
@@ -74,7 +74,7 @@ open class CardTypeRegister {
      
      - parameter cardTypes: The new range of card types contained in this card type register.
      */
-    public func setRegisteredCardTypes<T: Sequence>(_ cardTypes: T) where T.Iterator.Element == CardType {
+    open func setRegisteredCardTypes<T: Sequence>(_ cardTypes: T) where T.Iterator.Element == CardType {
         registeredCardTypes = [CardType]()
         registeredCardTypes.append(contentsOf: cardTypes)
     }
@@ -88,7 +88,7 @@ open class CardTypeRegister {
      
      - returns: An instance of UnknownCardType, if no card type matches the Issuer Identification Number of the provided card number or any other card type that matches the card number.
      */
-    public func cardType(for number: Number) -> CardType {
+    open func cardType(for number: Number) -> CardType {
         for i in (0...min(number.length, 6)).reversed() {
             if let substring = number.rawValue[0,i], let substringAsNumber = Int(substring) {
                 if let firstMatchingCardType = registeredCardTypes.filter({

--- a/Pod/Classes/Format/CardNumberFormatter.swift
+++ b/Pod/Classes/Format/CardNumberFormatter.swift
@@ -14,7 +14,7 @@ import UIKit
 public final class CardNumberFormatter {
 
     /// The separator which is used to separate different groups of a card number.
-    public let separator: String
+    open let separator: String
     
     /// The card type register which is used to access accepted card types. Formatting will only take place for card numbers whose card type can be found in this property.
     private var cardTypeRegister: CardTypeRegister
@@ -36,7 +36,7 @@ public final class CardNumberFormatter {
      
      - returns: The unformatted card number string representation.
      */
-    public func unformat(cardNumber: String) -> String {
+    open func unformat(cardNumber: String) -> String {
         return cardNumber.replacingOccurrences(of: self.separator, with: "")
     }
 
@@ -47,7 +47,7 @@ public final class CardNumberFormatter {
      
      - returns: Formatted card number string.
      */
-    public func format(cardNumber: String) -> String {
+    open func format(cardNumber: String) -> String {
         let regex: NSRegularExpression
 
         let cardType = cardTypeRegister.cardType(for: Number(rawValue: cardNumber))
@@ -77,7 +77,7 @@ public final class CardNumberFormatter {
      
      - returns: The index of the cursor position or nil, if no selected text was found.
      */
-    public func cursorPositionAfterUnformatting(_ text: String, in textField: UITextField) -> Int? {
+    open func cursorPositionAfterUnformatting(_ text: String, in textField: UITextField) -> Int? {
         guard let selectedRange = textField.selectedTextRange else {
             return nil
         }
@@ -162,7 +162,7 @@ public final class CardNumberFormatter {
      - parameter textField: The text field whose text should be changed.
      - parameter string:    The new string. This might be unformatted or badly formatted and will be formatted properly before being inserted into `textField`.
      */
-    public func format(range: NSRange, inTextField textField: UITextField, andReplaceWith string: String) {
+    open func format(range: NSRange, inTextField textField: UITextField, andReplaceWith string: String) {
         let newValueUnformatted = unformat(cardNumber: NSString(string: textField.text ?? "").replacingCharacters(in: range, with: string))
         let oldValueUnformatted = unformat(cardNumber: textField.text ?? "")
 

--- a/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
+++ b/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 
 extension CardTextField: CardInfoTextFieldDelegate {
 
-    public func textField(_ textField: UITextField, didEnterValidInfo: String) {
+    open func textField(_ textField: UITextField, didEnterValidInfo: String) {
         updateNumberColor()
         notifyDelegate()
         if expirationDateIsValid() {
@@ -18,12 +18,12 @@ extension CardTextField: CardInfoTextFieldDelegate {
         }
     }
     
-    public func textField(_ textField: UITextField, didEnterPartiallyValidInfo: String) {
+    open func textField(_ textField: UITextField, didEnterPartiallyValidInfo: String) {
         updateNumberColor()
         notifyDelegate()
     }
     
-    public func textField(_ textField: UITextField, didEnterOverflowInfo overFlowDigits: String) {
+    open func textField(_ textField: UITextField, didEnterOverflowInfo overFlowDigits: String) {
         updateNumberColor()
         select(textField, prefillText: overFlowDigits)
     }

--- a/Pod/Classes/UI/CardTextField+InterfaceBuilder.swift
+++ b/Pod/Classes/UI/CardTextField+InterfaceBuilder.swift
@@ -13,30 +13,30 @@ extension CardTextField {
             textFieldArray.forEach({$0?.textColor = textColor})
         }
     }
-    public override final var backgroundColor: UIColor? {
+    override public final var backgroundColor: UIColor? {
         didSet {
             numberInputTextField?.backgroundColor = backgroundColor
         }
     }
-    public override final var font: UIFont? {
+    override public final var font: UIFont? {
         didSet {
             let textFieldArray: [UITextField?] = [numberInputTextField, cvcTextField, monthTextField, yearTextField]
             textFieldArray.forEach({$0?.font = font})
         }
     }
-    public override final var keyboardType: UIKeyboardType {
+    override public final var keyboardType: UIKeyboardType {
         didSet {
             let textFieldArray: [UITextField?] = [numberInputTextField, cvcTextField, monthTextField, yearTextField]
             textFieldArray.forEach({$0?.keyboardType = keyboardType})
         }
     }
-    public override final var isSecureTextEntry: Bool {
+    override public final var isSecureTextEntry: Bool {
         didSet {
             let textFieldArray: [UITextField?] = [numberInputTextField, cvcTextField, monthTextField, yearTextField]
             textFieldArray.forEach({$0?.isSecureTextEntry = isSecureTextEntry})
         }
     }
-    public override final var keyboardAppearance: UIKeyboardAppearance {
+    override public final var keyboardAppearance: UIKeyboardAppearance {
         didSet {
             let textFieldArray: [UITextField?] = [numberInputTextField, cvcTextField, monthTextField, yearTextField]
             textFieldArray.forEach({$0?.keyboardAppearance = keyboardAppearance})

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -24,7 +24,7 @@ import UIKit
  */
 open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
-    // MARK: - open variables
+    // MARK: - Public variables
     
     /**
     The image view which is used to display the detected card type.

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -24,47 +24,47 @@ import UIKit
  */
 open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
-    // MARK: - Public variables
+    // MARK: - open variables
     
     /**
     The image view which is used to display the detected card type.
     */
-    @IBOutlet public weak var cardImageView: UIImageView?
+    @IBOutlet open weak var cardImageView: UIImageView?
     
     /**
      A but which is shown only when the delegate's
      */
-    @IBOutlet public weak var accessoryButton: UIButton?
+    @IBOutlet open weak var accessoryButton: UIButton?
     
     /**
      The formatted text field which is used to enter the card number.
      */
-    @IBOutlet public weak var numberInputTextField: NumberInputTextField!
+    @IBOutlet open weak var numberInputTextField: NumberInputTextField!
     
     /**
      The text field which is used to enter the card validation code.
      */
-    @IBOutlet public weak var cvcTextField: CVCInputTextField!
+    @IBOutlet open weak var cvcTextField: CVCInputTextField!
     
     /**
      The text field which is used to enter the month of the expiry date.
      */
-    @IBOutlet public weak var monthTextField: MonthInputTextField!
+    @IBOutlet open weak var monthTextField: MonthInputTextField!
     
     /**
      The text field which is used to enter the year of the expiry date.
      */
-    @IBOutlet public weak var yearTextField: YearInputTextField!
+    @IBOutlet open weak var yearTextField: YearInputTextField!
     
     /**
      The view which is slided in from the right after a valid card number has been entered.
      */
-    @IBOutlet public weak var cardInfoView: UIView?
+    @IBOutlet open weak var cardInfoView: UIView?
 
     /// The image store for the card number text field.
-    public var cardTypeImageStore: CardTypeImageStore = Bundle(for: CardTextField.self)
+    open var cardTypeImageStore: CardTypeImageStore = Bundle(for: CardTextField.self)
 
-    public var cardTextFieldDelegate: CardTextFieldDelegate? {
+    open var cardTextFieldDelegate: CardTextFieldDelegate? {
         didSet {
             setupAccessoryButton()
         }
@@ -73,7 +73,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      The string value that is used to separate the different groups of a card number in the text field.
      */
-    @IBInspectable public var cardNumberSeparator: String? = " - " {
+    @IBInspectable open var cardNumberSeparator: String? = " - " {
         didSet {
             numberInputTextField?.cardNumberSeparator = cardNumberSeparator ?? " - "
         }
@@ -82,12 +82,12 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      The duration of the view animation when switching from number input to detail.
      */
-    @IBInspectable public var viewAnimationDuration: Double = 0.3
+    @IBInspectable open var viewAnimationDuration: Double = 0.3
     
     /**
      The text color for invalid input in a text field.
      */
-    @IBInspectable public var invalidInputColor: UIColor? {
+    @IBInspectable open var invalidInputColor: UIColor? {
         didSet {
             guard let invalidInputColor = invalidInputColor else {
                 return
@@ -110,7 +110,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      Inset before the card type image view. Defaults to 1.0.
      */
-    @IBInspectable public var imageViewLeadingInset: CGFloat = 1.0 {
+    @IBInspectable open var imageViewLeadingInset: CGFloat = 1.0 {
         didSet {
             imageViewLeadingConstraint?.constant = imageViewLeadingInset
         }
@@ -124,7 +124,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      Inset after the card type image view. Defaults to 4.0.
      */
-    @IBInspectable public var imageViewTrailingInset: CGFloat = 4.0 {
+    @IBInspectable open var imageViewTrailingInset: CGFloat = 4.0 {
         didSet {
             imageViewTrailingConstraint?.constant = imageViewTrailingInset
         }
@@ -134,7 +134,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
      Inset before the accessory button. Defaults to 4.0.
      */
     @IBOutlet weak var accessoryButtonLeadingConstraint: NSLayoutConstraint?
-    @IBInspectable public var accessoryButtonLeadingInset: CGFloat = 4.0 {
+    @IBInspectable open var accessoryButtonLeadingInset: CGFloat = 4.0 {
         didSet {
             accessoryButtonLeadingConstraint?.constant = accessoryButtonLeadingInset
         }
@@ -144,7 +144,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
      Inset after the card type image view. Defaults to 5.0.
      */
     @IBOutlet weak var accessoryButtonTrailingConstraint: NSLayoutConstraint?
-    @IBInspectable public var accessoryButtonTrailingInset: CGFloat = 5.0 {
+    @IBInspectable open var accessoryButtonTrailingInset: CGFloat = 5.0 {
         didSet {
             accessoryButtonTrailingConstraint?.constant = accessoryButtonTrailingInset
         }
@@ -153,7 +153,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      The currently entered card values. Note that the values are not guaranteed to be valid.
      */
-    public var card: Card {
+    open var card: Card {
         get {
             let cardNumber = numberInputTextField.cardNumber
             let cardCVC = CVC(rawValue: cvcTextField.text ?? "")
@@ -169,7 +169,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
      This card type register contains a list of all valid card types. You can provide separate card type registers for different card number text fields.
      By default, CardTypeRegister.sharedCardTypeRegister is used.
      */
-    public var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister {
+    open var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister {
         didSet {
             numberInputTextField.cardTypeRegister = cardTypeRegister
         }
@@ -460,14 +460,14 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
     You can override this function to provide your own Nib. If you do so, please override 'getNibBundle' as well to provide the right NSBundle to load the nib file.
     */
-    public func getNibName() -> String {
+    open func getNibName() -> String {
         return "CardView"
     }
     
     /**
      You can override this function to provide the NSBundle for your own Nib. If you do so, please override 'getNibName' as well to provide the right Nib to load the nib file.
      */
-    public func getNibBundle() -> Bundle {
+    open func getNibBundle() -> Bundle {
         return Bundle(for: CardTextField.self)
     }
     
@@ -492,14 +492,14 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
                                              withValidationResult: result)
     }
     
-    @objc public func numberInputTextFieldDidChangeText(_ numberInputTextField: NumberInputTextField) {
+    @objc open func numberInputTextFieldDidChangeText(_ numberInputTextField: NumberInputTextField) {
         showCardImage()
         notifyDelegate()
         hideExpiryTextFields = !cardTypeRegister.cardType(for: numberInputTextField.cardNumber).requiresExpiry
         hideCVCTextField = !cardTypeRegister.cardType(for: numberInputTextField.cardNumber).requiresCVC
     }
     
-    public func numberInputTextFieldDidComplete(_ numberInputTextField: NumberInputTextField) {
+    open func numberInputTextFieldDidComplete(_ numberInputTextField: NumberInputTextField) {
         moveCardNumberOutAnimated()
         
         notifyDelegate()

--- a/Pod/Classes/UI/CardTypeImageStore.swift
+++ b/Pod/Classes/UI/CardTypeImageStore.swift
@@ -33,11 +33,11 @@ public protocol CardTypeImageStore {
 
 extension Bundle: CardTypeImageStore {
 
-    public func image(for cardType: CardType) -> UIImage? {
+    open func image(for cardType: CardType) -> UIImage? {
         return UIImage(named: cardType.name, in: self, compatibleWith: nil)
     }
 
-    public func cvcImage(for cardType: CardType) -> UIImage? {
+    open func cvcImage(for cardType: CardType) -> UIImage? {
         let cvcImageName: String
         if cardType.isEqual(to: AmericanExpress()) {
             cvcImageName = "AmexCVC"

--- a/Pod/Classes/UI/NumberInputTextField.swift
+++ b/Pod/Classes/UI/NumberInputTextField.swift
@@ -21,19 +21,19 @@ open class NumberInputTextField: StylizedTextField {
      
      - note: This card number may be incomplete and invalid while the user is entering a card number. Be sure to validate it against a proper card type before assuming it is valid.
      */
-    public var cardNumber: Number {
+    open var cardNumber: Number {
         let textFieldTextUnformatted = cardNumberFormatter.unformat(cardNumber: text ?? "")
         return Number(rawValue: textFieldTextUnformatted)
     }
     
     /**
      */
-    @IBOutlet public weak var numberInputTextFieldDelegate: NumberInputTextFieldDelegate?
+    @IBOutlet open weak var numberInputTextFieldDelegate: NumberInputTextFieldDelegate?
     
     /**
      The string that is used to separate different groups in a card number.
      */
-    @IBInspectable public var cardNumberSeparator: String = "-"
+    @IBInspectable open var cardNumberSeparator: String = "-"
     
     open override var accessibilityValue: String? {
         get {
@@ -78,7 +78,7 @@ open class NumberInputTextField: StylizedTextField {
     /**
      The card type register that holds information about which card types are accepted and which ones are not.
      */
-    public var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister
+    open var cardTypeRegister: CardTypeRegister = CardTypeRegister.sharedCardTypeRegister
     
     /**
      A card number formatter used to format the input
@@ -89,7 +89,7 @@ open class NumberInputTextField: StylizedTextField {
     
     // MARK: - UITextFieldDelegate
     
-    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    open override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         // Current text in text field, formatted and unformatted:
         let textFieldTextFormatted = NSString(string: textField.text ?? "")
         // Text in text field after applying changes, formatted and unformatted:
@@ -144,7 +144,7 @@ open class NumberInputTextField: StylizedTextField {
      
      - parameter text: The card number which should be displayed in `self`.
      */
-    public func prefill(_ text: String) {
+    open func prefill(_ text: String) {
         let unformattedCardNumber = String(text.characters.filter({$0.isNumeric()}))
         let cardNumber = Number(rawValue: unformattedCardNumber)
         let type = cardTypeRegister.cardType(for: cardNumber)
@@ -191,7 +191,7 @@ open class NumberInputTextField: StylizedTextField {
      
      - returns: The CGRect in `self` that contains the last group of the card number.
      */
-    public func rectForLastGroup() -> CGRect? {
+    open func rectForLastGroup() -> CGRect? {
         guard let lastGroupLength = text?.components(separatedBy: cardNumberFormatter.separator).last?.characters.count else {
             return nil
         }

--- a/Pod/Classes/UI/StylizedTextField.swift
+++ b/Pod/Classes/UI/StylizedTextField.swift
@@ -16,7 +16,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
      Changes to this parameter draw the border of `self` in the given width.
      */
     @IBInspectable
-    public var borderWidth: CGFloat = 0 {
+    open var borderWidth: CGFloat = 0 {
         didSet {
             if borderWidth >= 0 {
                 self.borderStyle = .none
@@ -32,7 +32,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
      If `borderWidth` has been set, changes to this parameter round the corners of `self` in the given corner radius.
      */
     @IBInspectable
-    public var cornerRadius: CGFloat = 0 {
+    open var cornerRadius: CGFloat = 0 {
         didSet {
             if cornerRadius >= 0 {
                 self.layer.cornerRadius = cornerRadius
@@ -44,7 +44,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
      If `borderWidth` has been set, changes to this parameter change the color of the border of `self`.
      */
     @IBInspectable
-    public var borderColor: UIColor = UIColor.black {
+    open var borderColor: UIColor = UIColor.black {
         didSet {
             self.layer.borderColor = self.borderColor.cgColor
         }
@@ -53,7 +53,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
     /**
      A method which will be called, when the delete key has been pressed for an empty text field.
      */
-    public var deleteBackwardCallback: ((UITextField) -> Void)?
+    open var deleteBackwardCallback: ((UITextField) -> Void)?
     
     open override var text: String? {
         didSet {
@@ -69,7 +69,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
     /**
      The color in which text flashes, when the user is about to enter an invalid card number.
      */
-    @IBInspectable public var invalidInputColor: UIColor = UIColor.red
+    @IBInspectable open var invalidInputColor: UIColor = UIColor.red
     
     public required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
@@ -109,7 +109,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
         
     }
     
-    public func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return true
     }
 }

--- a/Pod/Classes/UI/Text Fields/CVCInputTextField.swift
+++ b/Pod/Classes/UI/Text Fields/CVCInputTextField.swift
@@ -12,7 +12,7 @@ import UIKit
 open class CVCInputTextField: DetailInputTextField {
     
     /// The card type for the CVC that should be entered. The length of a CVC can vary based on this card type.
-    public var cardType: CardType?
+    open var cardType: CardType?
     override var expectedInputLength: Int {
         return cardType?.CVCLength ?? 3
     }

--- a/Pod/Classes/UI/Text Fields/DetailInputTextField.swift
+++ b/Pod/Classes/UI/Text Fields/DetailInputTextField.swift
@@ -15,15 +15,15 @@ import UIKit
  */
 open class DetailInputTextField: StylizedTextField {
     
-    public var cardInfoTextFieldDelegate: CardInfoTextFieldDelegate?
+    open var cardInfoTextFieldDelegate: CardInfoTextFieldDelegate?
     
-    public func textFieldDidBeginEditing(_ textField: UITextField) {
+    open func textFieldDidBeginEditing(_ textField: UITextField) {
         if (textField.text ?? "").isEmpty {
             textField.text = UITextField.emptyTextFieldCharacter
         }
     }
     
-    public override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+    open override func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         let newText = NSString(string: (textField.text ?? "")).replacingCharacters(in: range, with: string).replacingOccurrences(of: UITextField.emptyTextFieldCharacter, with: "")
         
         let deletingLastCharacter = !(textField.text ?? "").isEmpty && textField.text != UITextField.emptyTextFieldCharacter && newText.isEmpty
@@ -53,7 +53,7 @@ open class DetailInputTextField: StylizedTextField {
         return false
     }
     
-    public func prefill(_ text: String) {
+    open func prefill(_ text: String) {
         if isInputValid(text, partiallyValid: false) {
             self.text = text
             cardInfoTextFieldDelegate?.textField(self, didEnterValidInfo: text)


### PR DESCRIPTION
To remain compatible with the implementation before Swift 3 migration, publicly declared variables should be open as far as possible as this comes closer to the semantic of public before Swift 3.