### PR TITLE
Fix Placeholders

### DIFF
--- a/Pod/Classes/UI/StylizedTextField.swift
+++ b/Pod/Classes/UI/StylizedTextField.swift
@@ -105,10 +105,6 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
         }
     }
     
-    open override func drawPlaceholder(in rect: CGRect) {
-        
-    }
-    
     open func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
         return true
     }


### PR DESCRIPTION
Currently the library is trying to draw placeholders twice. The empty function drawPlaceholders rewrites the placeholder to empty. This PR removes the drawing over