### PR TITLE
[Swift 4] Cleanup Convenience Initializers

### DIFF
--- a/Pod/Classes/Cards/Expiry.swift
+++ b/Pod/Classes/Cards/Expiry.swift
@@ -52,14 +52,14 @@ public struct Expiry: RawRepresentable {
         }
         
         let monthRange = match.range(at: 1)
-        if monthRange.length > 0, let range = string.rangeFrom(monthRange) {
+        if monthRange.length > 0, let range = Range(monthRange, in: string) {
             monthStr = String(string[range])
         } else {
             return nil
         }
         
         let yearRange = match.range(at: 2)
-        if yearRange.length > 0, let range = string.rangeFrom(yearRange) {
+        if yearRange.length > 0, let range = Range(yearRange, in: string) {
             yearStr = String(string[range])
         } else {
             return nil

--- a/Pod/Classes/StringExtension.swift
+++ b/Pod/Classes/StringExtension.swift
@@ -13,41 +13,6 @@ extension String {
     //http://stackoverflow.com/a/30404532/1565974
     
     /**
-     Converts an NSRange object for characters in `self` to a Range<String.Index> for use in methods expecting a Range.
-     
-     - parameter nsRange: The NSRange object that should be converted to Range.
-     
-     - returns: `nsRange` converted to Range<String.Index> or nil, if its start and/or end location are not within `self`.
-     */
-    func rangeFrom(_ nsRange: NSRange) -> Range<String.Index>? {
-        guard let from16 = utf16.index(utf16.startIndex, offsetBy: nsRange.location, limitedBy: utf16.endIndex) else {
-            return nil
-        }
-        guard let to16 = utf16.index(from16, offsetBy: nsRange.length, limitedBy: utf16.endIndex) else {
-            return nil
-        }
-        if let from = String.Index(from16, within: self),
-            let to = String.Index(to16, within: self) {
-                return from ..< to
-        }
-        return nil
-    }
-
-    /**
-     Converts a Range<String.Index> object in `self` to an NSRange object for use in methods expecting an NSRange.
-     
-     - parameter range: The Range object that should be converted to NSRange.
-     
-     - returns: An NSRange object that is equivalent to `range`.
-     */
-    func NSRangeFrom(_ range : Range<String.Index>) -> NSRange {
-        let utf16view = self.utf16
-        let from = String.UTF16View.Index(range.lowerBound, within: utf16view)
-        let to = String.UTF16View.Index(range.upperBound, within: utf16view)
-        return NSMakeRange(utf16view.distance(from: startIndex, to: from!), utf16view.distance(from: from!, to: to!))
-    }
-    
-    /**
      Convenience method to retreive a substring of `self`.
      
      - parameter fromInclusively: The index of the first character that should be included in the substring.


### PR DESCRIPTION
Removed custom functions to create a NSRange from Range or Range from NSRange in a given string, as there are now designated initializers for this.