### PR TITLE
Allow slashLabel to be modified/customized.

### DIFF
--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -100,7 +100,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     /**
      The label which is used as separator inbetween the text fields for month and year of the card expiry.
      */
-    @IBOutlet weak var slashLabel: UILabel!
+    @IBOutlet open weak var slashLabel: UILabel!
     
     /**
      The view constraint which insets the card image view from its superview's leading edge.


### PR DESCRIPTION
I'm working on a project where we need to customize the font and color of `slashLabel` with Swift 3.2. This PR opens the label to allow the modification/customization in Xcode 9 (which currently throws the error below).

<img width="261" alt="screen shot 2017-09-12 at 9 45 09 am" src="https://user-images.githubusercontent.com/2159852/30329026-19c0a60a-979f-11e7-9422-2e73020d5c4c.png">
