### PR TITLE
Fix Podspec to move XIBs to Resources

### DIFF
--- a/Caishen.podspec
+++ b/Caishen.podspec
@@ -28,6 +28,6 @@ Pod::Spec.new do |s|
   s.platform     = :ios, '8.0'
   s.requires_arc = true
 
-  s.source_files = 'Pod/Classes/**/*'
-  s.resources = ['Pod/Assets/*', 'Pod/Resources/*']
+  s.source_files = 'Pod/Classes/**/*.swift'
+  s.resources = ['Pod/Assets/*', 'Pod/Resources/*', 'Pod/**/*.{xib}']
 end


### PR DESCRIPTION
XIB files were being marked as source files instead of Resources