### PR TITLE
Fixed StylizedTextField subclassing

### DIFF
--- a/Pod/Classes/UI/StylizedTextField.swift
+++ b/Pod/Classes/UI/StylizedTextField.swift
@@ -77,7 +77,7 @@ open class StylizedTextField: UITextField, UITextFieldDelegate {
         self.delegate = self
     }
     
-    override init(frame: CGRect) {
+    public override init(frame: CGRect) {
         super.init(frame: frame)
         
         self.delegate = self


### PR DESCRIPTION
Subclasses of `DetailInputTextField` crashes in runtime because `StylizedTextField.init(frame:)` is internal.