### PR TITLE
Fix memory leak and fix crash

### DIFF
--- a/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
+++ b/Pod/Classes/UI/CardTextField+CardInfoTextFieldDelegate.swift
@@ -44,7 +44,7 @@ extension CardTextField: CardInfoTextFieldDelegate {
 
         // Let the next text field become first responder if one of the contained text fields
         // already is first responder.
-        if isFirstResponder {
+        if isChildFirstResponder {
             nextTextField?.becomeFirstResponder()
         }
 

--- a/Pod/Classes/UI/CardTextField+PrefillInformation.swift
+++ b/Pod/Classes/UI/CardTextField+PrefillInformation.swift
@@ -43,7 +43,7 @@ extension CardTextField {
             cvcTextField?.prefill(cvc)
         }
 
-        moveCardNumberOutAnimated(remainFirstResponder: isFirstResponder)
+        moveCardNumberOutAnimated(remainFirstResponder: isChildFirstResponder)
         
         notifyDelegate()
     }

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -191,7 +191,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
         }
     }
 
-    open override var isFirstResponder: Bool {
+    open var isChildFirstResponder: Bool {
         // Return true if any of `self`'s subviews is the current first responder.
         return [numberInputTextField,monthTextField,yearTextField,cvcTextField]
             .filter({$0.isFirstResponder})
@@ -417,7 +417,7 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
 
     /// Function for the swipe gesture recognizer for moving out the card number.
     @objc private func swipeHideCardNumber() {
-        moveCardNumberOutAnimated(remainFirstResponder: isFirstResponder)
+        moveCardNumberOutAnimated(remainFirstResponder: isChildFirstResponder)
     }
 
     /**
@@ -506,12 +506,12 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
     
     open func numberInputTextFieldDidComplete(_ numberInputTextField: NumberInputTextField) {
         // Retain the first responder status if currently first responder.
-        moveCardNumberOutAnimated(remainFirstResponder: isFirstResponder)
+        moveCardNumberOutAnimated(remainFirstResponder: isChildFirstResponder)
         
         notifyDelegate()
         hideExpiryTextFields = !cardTypeRegister.cardType(for: numberInputTextField.cardNumber).requiresExpiry
         hideCVCTextField = !cardTypeRegister.cardType(for: numberInputTextField.cardNumber).requiresCVC
-        if hideExpiryTextFields && hideCVCTextField || !isFirstResponder {
+        if hideExpiryTextFields && hideCVCTextField || !isChildFirstResponder {
             return
         } else if hideExpiryTextFields {
             cvcTextField.becomeFirstResponder()
@@ -602,24 +602,5 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
         default:
             return nil
         }
-    }
-    
-    open override func becomeFirstResponder() -> Bool {
-        // Return false if any of this text field's subviews is already first responder. 
-        // Otherwise let `numberInputTextField` become the first responder.
-        if [numberInputTextField,monthTextField,yearTextField,cvcTextField]
-            .map({return $0.isFirstResponder})
-            .reduce(true, {$0 && $1}) {
-            return false
-        }
-        return numberInputTextField.becomeFirstResponder()
-    }
-    
-    open override func resignFirstResponder() -> Bool {
-        // If any of `self`'s subviews is first responder, resign first responder status.
-        return [numberInputTextField,monthTextField,yearTextField,cvcTextField]
-            .filter({$0.isFirstResponder})
-            .first?
-            .resignFirstResponder() ?? true
     }
 }

--- a/Pod/Classes/UI/CardTextField.swift
+++ b/Pod/Classes/UI/CardTextField.swift
@@ -603,4 +603,20 @@ open class CardTextField: UITextField, NumberInputTextFieldDelegate {
             return nil
         }
     }
+    
+    open override func becomeFirstResponder() -> Bool {
+        super.becomeFirstResponder()
+        super.resignFirstResponder()
+        return false
+    }
+    
+    open override func resignFirstResponder() -> Bool {
+        // If any of `self`'s subviews is first responder, resign first responder status.
+        [numberInputTextField,monthTextField,yearTextField,cvcTextField]
+            .filter({$0.isFirstResponder})
+            .first?
+            .resignFirstResponder()
+        
+        return super.resignFirstResponder()
+    }
 }


### PR DESCRIPTION
Remove the overrides to becomeFirstResponder, resignFirstResponder, and isFirstResponder as they are causing UIKit to behave erroneously by creating a strong reference to the CardTextField that is not being released. Please see [Issue #151](https://github.com/prolificinteractive/Caishen/issues/151) for details and reproducible steps.

My theory is that UIKit is having trouble that both the CardTextField and the child text field (NumberInputTextField for example) were both claiming to be the first responder at the same time.

Note that this could potentially be a breaking change if someone was relying on the logic in these overriden functions.